### PR TITLE
Add support for subaccounts

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -324,6 +324,11 @@ func (c *Canvas) Accounts(opts ...Option) ([]Account, error) {
 	return getAccounts(c.client, "/accounts", opts)
 }
 
+// SubAccounts will list the sub_accounts under an account
+func (c *Canvas) SubAccounts(accountId int, opts ...Option) ([]Account, error) {
+	return getAccounts(c.client, fmt.Sprintf("/accounts/%d/sub_accounts", accountId), opts)
+}
+
 // Accounts will list the accounts
 func Accounts(opts ...Option) ([]Account, error) { return ca.Accounts() }
 


### PR DESCRIPTION
I need to be able to query for sub accounts. I tested with the v.0.0.1 tag and it worked fine. Seems like master is broken right now, in terms of the client working.